### PR TITLE
feat(creator): claim page for adrian-from-robomarketing

### DIFF
--- a/_creators/adrian-from-robomarketing/adrian-from-robomarketing.md
+++ b/_creators/adrian-from-robomarketing/adrian-from-robomarketing.md
@@ -15,14 +15,14 @@ header_gradient: "linear-gradient(135deg, #0ea5e9 0%, #6366f1 100%)"
 
 # useful links
 links:
-  - "https://creators.n8n.io/dashboard"
+  - "https://n8n.io/creators/adrian-from-robomarketing"
   - "mailto:ulmeanu.a@gmail.com"
   - "https://github.com/ulmeanuadrian"
   - "https://www.linkedin.com/in/ulmeanuadrian/"
 
 # offers
 offer1:
-  title: "Social Media Automation with n8n"
+  title: "Generate & Publish Social Media Conten (Late)"
   description_html: "End-to-end automation for content creation and publishing with <b>Gemini</b> and <b>Late API</b>. Fast setup and full support."
   link: "mailto:ulmeanu.a@gmail.com"
   cta: "Get in touch"
@@ -32,10 +32,4 @@ offer2:
   description_html: "Conversational assistant powered by <b>Gemini AI</b>, CRM integration, and persistent memory. Demo available on request."
   link: "mailto:ulmeanu.a@gmail.com"
   cta: "Request a demo"
-
-offer3:
-  title: "Generate & Publish Social Media Content"
-  description_html: "This workflow automates end-to-end social media publishing powered by <b>Late API"
-  link: "mailto:ulmeanu.a@gmail.com"
-  cta: "Try it"
 ---


### PR DESCRIPTION
Claiming creator page for "adrian-from-robomarketing".

- Set page_status to "claimed"
- Added creator_name, bio, and header gradient
- Added links (n8n dashboard, email, GitHub, LinkedIn)
- Added offers with clear CTA

n8n username: adrian-from-robomarketing
LinkedIn: https://www.linkedin.com/in/ulmeanuadrian/
